### PR TITLE
Change location of video files (0.1.1)

### DIFF
--- a/dashcammer
+++ b/dashcammer
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-mkdir -p /home/dashcam/videos/all
+VIDEO_TEMP_LOCATION=/var/tmp/dashcammer
+
+mkdir -p "$VIDEO_TEMP_LOCATION"
 
 raspivid -w 1920 -h 1080 -fps 25 -b 15000000 --segment 60000 -t 0 \
-    -o '/home/dashcam/videos/all/%FT%T%z.h264'
+    -o "$VIDEO_TEMP_LOCATION/%FT%T%z.h264"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,9 @@
-dashcammer (0.1.0) UNRELEASED; urgency=low
+dashcammer (0.1.1) UNRELEASED; urgency=low
 
   * Keep install location consistent and support systemd
+  * Use /var/tmp/dashcammer for video location
 
- -- Dan <dan@danplayle.com>  Mon, 02 Jan 2023 10:58:48 +0000
+ -- Daniel Playle <code@danplayle.com>  Mon, 02 Jan 2023 14:57:13 +0000
 
 dashcammer (0.0.1) UNRELEASED; urgency=low
 


### PR DESCRIPTION
This commit changes the location of the video files away from the home directory and into `/var/tmp/dashcammer`.

Fixes https://github.com/dp0/dashcammer/issues/7