### PR TITLE
Add gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+debian/.debhelper/
+debian/dashcammer.postinst.debhelper
+debian/dashcammer.postrm.debhelper
+debian/dashcammer.prerm.debhelper
+debian/dashcammer.substvars
+debian/dashcammer
+debian/debhelper-build-stamp
+debian/files


### PR DESCRIPTION
This commit introduced a gitignore to avoid accidentially tracking debian metadata that isn't used.

Fixes https://github.com/dp0/dashcammer/issues/8